### PR TITLE
Desativando csrf para impedir taques de roubo de session

### DIFF
--- a/src/main/java/com/project/carros/Security/SecurityConfig.java
+++ b/src/main/java/com/project/carros/Security/SecurityConfig.java
@@ -16,6 +16,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter{
 		    .anyRequest()
 		        .authenticated()
 		        .and()
-		        .httpBasic();
+		        .httpBasic()
+		             .and()
+		              .csrf().disable();
  	}
 }


### PR DESCRIPTION
## Status
**EM DESENVOLVIMENTO**

## Descrição
Desativando csrf para impedir taques de roubo de session

## Todos
- [] Testes
- [] Documentação

## Etapas para testar ou reproduzir
 
 
```sh
mvn spring-boot:run
```
